### PR TITLE
#1211 sendgrid Events not JSON serializable for celery

### DIFF
--- a/sendgrid_events/views.py
+++ b/sendgrid_events/views.py
@@ -20,11 +20,19 @@ def handle_batch_post(request):
     if background_process:
         if queue:
             process_batch.apply_async(
-                kwargs={'data': request.body},
+                kwargs={
+                    'data': request.body,
+                    'json_compatible': True
+                },
                 queue=queue
             )
         else:
-            process_batch.apply_async(kwargs={'data': request.body})
+            process_batch.apply_async(
+                kwargs={
+                    'data': request.body,
+                    'json_compatible': True
+                }
+            )
 
     else:
         Event.process_batch(data=request.body)


### PR DESCRIPTION
- make sure the result is always json-serializable if the process is run in the background
